### PR TITLE
Keep decimal point in numbers specified as floats/doubles.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@
  * node-sqlparser: index.js
  * Create   : 2014-05-21 18:05:12
  */
-module.exports = require('./lib/ast');
+exports.AST = require('./lib/ast');
+exports.parse = require('./lib/parse').parse;
+exports.stringify = require('./lib/stringify');

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1,17 +1,25 @@
-var parse = require('./parser');
+/**
+ * @class  AST Helper
+ */
+var parse = require('./parse').parse;
 var stringify = require('./stringify');
 
 function AST(ast) {
   this.ast = ast;
 }
 
-AST.parse = parse;
-AST.stringify = stringify;
-
 AST.prototype = {
+  /**
+   * parse sql string to ast object
+   * @param  {String} sql
+   */
   parse: function (sql) {
     this.ast = parse(sql);
   },
+  /**
+   * stringify ast object to sql
+   * @return {String} sql
+   */
   stringify: function () {
     return stringify(this.ast);
   },

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -458,10 +458,10 @@ module.exports = (function() {
               value: n
             }
           },
-        peg$c153 = function(int_, frac, exp) { return parseFloat(int_ + frac + exp); },
-        peg$c154 = function(int_, frac) { return parseFloat(int_ + frac);       },
-        peg$c155 = function(int_, exp) { return parseFloat(int_ + exp);        },
-        peg$c156 = function(int_) { return parseFloat(int_);              },
+        peg$c153 = function(int_, frac, exp) { var x = parseFloat(int_ + frac + exp); return (x % 1 != 0) ? x.toString() : x.toString() + ".0"},
+        peg$c154 = function(int_, frac) { var x = parseFloat(int_ + frac); return (x % 1 != 0) ? x.toString() : x.toString() + ".0"},
+        peg$c155 = function(int_, exp) { return parseFloat(int_ + exp).toString(); },
+        peg$c156 = function(int_) { return parseFloat(int_).toString(); },
         peg$c157 = function(digit19, digits) { return digit19 + digits;       },
         peg$c158 = function(op, digit19, digits) { return "-" + digit19 + digits; },
         peg$c159 = function(op, digit) { return "-" + digit;            },

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -141,8 +141,6 @@ function columnRefToSQL(e) {
   }
 }
 
-exports.exprToSQL = exprToSQL;
-
 function exprToSQL(e) {
   var t = e.type;
   var res ;
@@ -438,3 +436,6 @@ module.exports = function (ast, opt) {
   }
   return res;
 };
+
+module.exports.exprToSQL = exprToSQL;
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "node-sqlparser",
   "description": "a sql parser for node.js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "url": "git://github.com/alibaba/nquery.git"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "node-sqlparser",
   "description": "a sql parser for node.js",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "repository": {
     "url": "git://github.com/alibaba/nquery.git"
   },

--- a/peg/sqlparser.pegjs
+++ b/peg/sqlparser.pegjs
@@ -816,10 +816,10 @@ literal_int "LITERAL INT"
   }
 
 number
-  = int_:int frac:frac exp:exp __ { return parseFloat(int_ + frac + exp); }
-  / int_:int frac:frac __         { return parseFloat(int_ + frac);       }
-  / int_:int exp:exp __           { return parseFloat(int_ + exp);        }
-  / int_:int __                   { return parseFloat(int_);              }
+  = int_:int frac:frac exp:exp __ { var x = parseFloat(int_ + frac + exp); return (x % 1 != 0) ? x.toString() : x.toString() + ".0"}
+  / int_:int frac:frac __         { var x = parseFloat(int_ + frac); return (x % 1 != 0) ? x.toString() : x.toString() + ".0"}
+  / int_:int exp:exp __           { return parseFloat(int_ + exp).toString(); }
+  / int_:int __                   { return parseFloat(int_).toString(); }
 
 int
   = digit19:digit19 digits:digits     { return digit19 + digits;       }

--- a/test/unit/select.test.js
+++ b/test/unit/select.test.js
@@ -13,7 +13,7 @@ describe('SQL select', function () {
 
   describe('check selected fields', function () {
     it('should return ok when simple fields', function () {
-      var sql = 'select custom(abc), def from a.tablename where custom(id) in (1, 2, 2, 3) and c = ?';
+      var sql = 'select custom(abc), def from a.tablename where custom(id) in (1.0, 2.1, 2, 3) and c = ?';
       var result = parser.parse(sql);
       var resSql = stringify(result);
       expect(result)
@@ -27,6 +27,15 @@ describe('SQL select', function () {
       expect(result)
         .type('select')
         .columns(['sum(abc,1)', 'def']);
+    });
+    it('should keep decimals in floats', function () {
+      var sql = 'select a from b where x = 1.0';
+      var result = parser.parse(sql);
+      var resSql = stringify(result);
+      expect(result)
+        .type('select')
+        .columns(['a']);
+      resSql.toLowerCase().should.equal(sql);
     });
     it('should ok when limit 10', function () {
       var sql = 'select a from b limit 10';


### PR DESCRIPTION
Prevents parsing errors in some SQL implementations that require a decimal point for doubles.